### PR TITLE
Added timeout to isInternetAvailable

### DIFF
--- a/src/function.js
+++ b/src/function.js
@@ -3,6 +3,7 @@ const http2 = require('http2');
 /**
  * @param {Object} [options]
  * @param {String} [options.authority]
+ * @param {Number} [options.timeout]
  * @param {Object} [options.options]
  */
 function isInternetAvailable(options = {
@@ -14,6 +15,15 @@ function isInternetAvailable(options = {
       resolve(true);
       client.destroy();
     });
+
+    if (typeof options.timeout === 'number') {
+      client.setTimeout(options.timeout);
+      client.on('timeout', () => {
+        resolve(false);
+        client.destroy();
+      });
+    }
+
     client.on('error', () => {
       resolve(false);
       client.destroy();

--- a/src/test.js
+++ b/src/test.js
@@ -5,3 +5,18 @@ const pkg = require('./index');
 const service = new pkg.InternetAvailabilityService({ rate: 1000 });
 service.on('checking', () => console.log('checking connection'));
 service.on('status', (value) => console.log('connection status changed to', value));
+
+(async () => {
+  const TIMEOUT = 1;
+  const isInternetAvailableWithTimeout = await pkg.isInternetAvailable({
+    timeout: TIMEOUT,
+  })
+
+  if (isInternetAvailableWithTimeout === true) {
+    throw new Error(
+      `The connection test with \
+timeout should have returned false. \
+It is unlikely that it has connected in ${TIMEOUT}ms`
+    )
+  }
+})()


### PR DESCRIPTION
I found this useful, because I needed to test the internet connection in jest tests. I needed to test very slow responses and redirect the control flow depending on it. I added the timeout as per [Node Docs](https://nodejs.org/api/http2.html#event-timeout). Do you find this sufficiently useful? Thanks